### PR TITLE
Hotfix: Transmogrify action wasn't updating coins

### DIFF
--- a/src/components/header/Inventory.js
+++ b/src/components/header/Inventory.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef } from 'react';
 import {
   drop,
   examine,
@@ -7,27 +7,28 @@ import {
   carry,
   receive,
   playerStatus,
-  wear
-} from "../../actions/";
-import { useStateValue } from "../../hooks/useStateValue";
-import InventoryActions from "./InventoryActions";
+  wear,
+  getBalance,
+} from '../../actions/';
+import { useStateValue } from '../../hooks/useStateValue';
+import InventoryActions from './InventoryActions';
 
 export const Inventory = () => {
   const [{ playerState }, dispatch] = useStateValue();
   const [showInventory, setShowInventory] = useState(false); // inventoryMenu visibility
-  const [selectedItem, setSelectedItem] = useState(""); // string of item name
+  const [selectedItem, setSelectedItem] = useState(''); // string of item name
 
   //----- hides inventoryMenu when user clicks outside menu
   const node = useRef();
   useEffect(() => {
     if (showInventory)
-      document.addEventListener("mousedown", handleClickOutside);
-    else document.removeEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
+      document.addEventListener('mousedown', handleClickOutside);
+    else document.removeEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [showInventory]);
-  const handleClickOutside = e => {
+  const handleClickOutside = (e) => {
     if (node.current.contains(e.target)) return;
-    setSelectedItem(""); // reset item
+    setSelectedItem(''); // reset item
     setShowInventory(false); // close menu
   };
   //-----
@@ -38,55 +39,56 @@ export const Inventory = () => {
     // e.currentTarget.classList.toggle("pressed") - save it for a future sprint - complicates the user expectations
   };
 
-  const submitAction = async action => {
+  const submitAction = async (action) => {
     switch (action) {
-      case "sell":
+      case 'sell':
         await sell(dispatch, selectedItem);
         playerStatus(dispatch);
         break;
-      case "transmogrify":
+      case 'transmogrify':
         await transmogrify(dispatch, selectedItem);
         playerStatus(dispatch);
+        getBalance(dispatch);
         break;
-      case "examine":
+      case 'examine':
         examine(dispatch, selectedItem);
         break;
-      case "drop":
+      case 'drop':
         await drop(dispatch, selectedItem);
         playerStatus(dispatch);
         break;
-      case "carry":
+      case 'carry':
         carry(dispatch, selectedItem);
         break;
-      case "wear":
+      case 'wear':
         wear(dispatch, selectedItem);
         playerStatus(dispatch);
         break;
-      case "receive":
+      case 'receive':
         receive(dispatch);
         break;
       default:
         break;
     }
     setShowInventory(false); // close menu
-    setSelectedItem(""); // reset item
+    setSelectedItem(''); // reset item
   };
 
   return (
     <div ref={node}>
       <div
         className={
-          showInventory ? "inventoryButton inventoryPressed" : "inventoryButton"
+          showInventory ? 'inventoryButton inventoryPressed' : 'inventoryButton'
         }
         onClick={() => setShowInventory(!showInventory)}
       >
-        <p>Inventory {showInventory ? "▴" : "▾"}</p>
+        <p>Inventory {showInventory ? '▴' : '▾'}</p>
       </div>
       {showInventory && (
         <div className="inventoryMenu">
           <ul className="inventoryGrid">
             {playerState.inventory.map((item, i) => (
-              <li key={i} onClick={e => handleItem(e, item)}>
+              <li key={i} onClick={(e) => handleItem(e, item)}>
                 {item}
               </li>
             ))}


### PR DESCRIPTION
Added the `getBalance` action in order to get the coins to re-render. It originally only had `playerStatus`, which would update the inventory but the coin stats were a separate call.

_Note_: I was noticing that some of the actions in the inventory page were awaits and other weren't. Maybe go through them and maybe them more consistent?